### PR TITLE
Fix path handling for modulogram pipeline

### DIFF
--- a/modulogram_pipeline.m
+++ b/modulogram_pipeline.m
@@ -3,7 +3,9 @@ function modulogram_pipeline(config)
 %   MODULOGRAM_PIPELINE(CONFIG) loops over subjects and channels for a
 %   specified session and alignments. Helper functions live in src/.
 
-addpath('src');
+% Ensure helper functions in the src directory are on the MATLAB path
+scriptDir = fileparts(mfilename('fullpath'));
+addpath(fullfile(scriptDir, 'src'));
 
 % Default FIR filter order if not specified
 if ~isfield(config, 'fir_order')


### PR DESCRIPTION
## Summary
- ensure `modulogram_pipeline` adds its `src` directory based on the file location so it works when invoked from any path

## Testing
- `matlab -batch "disp('Testing environment');"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855688ad1208326917bc1ecf8ea234c