### PR TITLE
Discriminate modulogram figures by alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Most scripts expect data files that are not part of this repository (e.g., `loss
    execute2
    ```
    which will call `modulogram_pipeline(config)`.
+   Modulogram images for each channel are written to
+   `resultsDir/<Subject>/Session_<N>/<alignment>/CH###_<alignment>_Modulogram.png`.
 3. After modulograms are generated, use `config_stats.m` followed by `run_pac_stats.m` to compute summary statistics and plots.
 
 ## Requirements

--- a/src/create_single_modulogram.m
+++ b/src/create_single_modulogram.m
@@ -100,9 +100,9 @@ end
 finalAggAmplP = normalized_aggAmplP_sub;
 finalAggMI = aggMI_sub;
 
-resultsDir = fullfile(config.resultsDir, subjectID, sprintf('Session_%d', sessionNum));
+resultsDir = fullfile(config.resultsDir, subjectID, sprintf('Session_%d', sessionNum), alignment);
 if ~exist(resultsDir,'dir'); mkdir(resultsDir); end
-outFile = fullfile(resultsDir, sprintf('CH%s_Modulogram.png', channelLabel));
+outFile = fullfile(resultsDir, sprintf('CH%s_%s_Modulogram.png', channelLabel, alignment));
 plot_modulogram_figure(finalAggAmplP, finalAggMI, binCenters_trial, centerFreqs, outFile, anatomicalRegion);
 
 fprintf('[✓] Completed channel %s (%s) with %d trials and %d gamma bands.\n', channelLabel, anatomicalRegion, nTrials, numGammaBands);


### PR DESCRIPTION
## Summary
- write modulogram figure files to an alignment-specific folder
- document new location of image outputs in README

## Testing
- `octave --version | head -n 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855752aae448326953bab93cda5c818