### PR TITLE
Add PAC descriptive regression models

### DIFF
--- a/PAC_DescriptiveModels/basic_logreg_bandwise_MI.m
+++ b/PAC_DescriptiveModels/basic_logreg_bandwise_MI.m
@@ -1,0 +1,44 @@
+function basic_logreg_bandwise_MI(modulogramStruct, outcomeLabels)
+%% BASIC_LOGREG_BANDWISE_MI  Logistic regression on band-wise MI.
+%  BASIC_LOGREG_BANDWISE_MI(modStruct, labels) fits a logistic regression
+%  predicting LABELS (1=win,0=loss) from the modulation index (MI) in
+%  MODSTRUCT.MI_per_trial. Each frequency band contributes one predictor.
+%
+%  The script validates input dimensions, fits the model, and stores results
+%  in a timestamped subdirectory of PAC_DescriptiveModels/Results.
+%  Outputs include coefficient tables, diagnostic plots (ROC curve,
+%  confusion matrix, residuals), and the fitted GLM object.
+%
+%  Result files are suitable for quick descriptive analysis of PAC effects.
+%
+%  Example:
+%      basic_logreg_bandwise_MI(allData.EMU024.session(1).alignment.loss.channel.CH057, labels)
+%
+%  See also SAVE_MODEL_SUMMARY.
+
+% Validate inputs
+MI = modulogramStruct.MI_per_trial;
+[nBands, nTrials] = size(MI);
+assert(numel(outcomeLabels) == nTrials, 'Outcome labels must match trial count');
+
+% Build predictor table
+featureNames = strcat('MI_B', string(1:nBands));
+X = array2table(MI', 'VariableNames', featureNames);
+T = [X, table(outcomeLabels(:), 'VariableNames', {'Outcome'})];
+
+% Fit logistic regression
+% Expand formula to include all bands
+formula = ['Outcome ~ 1'];
+for i = 1:nBands
+    formula = [formula, ' + MI_B', num2str(i)]; %#ok<AGROW>
+end
+mdl = fitglm(T, formula, 'Distribution','binomial');
+
+% Prepare result directory
+timestamp = datestr(now,'yyyy-mm-dd_HH-MM');
+resultDir = fullfile('PAC_DescriptiveModels','Results', ['basic_MI_' timestamp]);
+if ~exist(resultDir,'dir'); mkdir(resultDir); end
+
+% Save outputs
+save_model_summary(mdl, resultDir, featureNames);
+end

--- a/PAC_DescriptiveModels/logreg_with_interactions.m
+++ b/PAC_DescriptiveModels/logreg_with_interactions.m
@@ -1,0 +1,61 @@
+function logreg_with_interactions(modulogramStruct, outcomeLabels)
+%% LOGREG_WITH_INTERACTIONS Logistic regression with MI interactions.
+%  LOGREG_WITH_INTERACTIONS(modStruct, labels) fits a logistic regression
+%  using modulation index (MI) from each band and also includes pairwise
+%  interaction terms between bands (i.e., the product of two band MIs).
+%
+%  The intent is to evaluate whether co-modulation of frequency bands better
+%  predicts the outcome than individual bands alone.
+%
+%  Results are stored in a timestamped folder under
+%  PAC_DescriptiveModels/Results/logreg_interactions_<timestamp>/.
+%
+%  The folder includes coefficient tables, diagnostic plots, ROC curve,
+%  confusion matrix, and the fitted GLM object.
+%
+%  Example:
+%      logreg_with_interactions(modStruct, labels)
+%
+%  See also SAVE_MODEL_SUMMARY.
+
+% Validate inputs
+MI = modulogramStruct.MI_per_trial;
+[nBands, nTrials] = size(MI);
+assert(numel(outcomeLabels) == nTrials, 'Outcome labels must match trial count');
+
+% Base predictors
+featureNames = strcat('MI_B', string(1:nBands));
+X = MI'; % nTrials x nBands
+
+% Generate interaction terms
+interNames = {};
+interData = [];
+for i = 1:nBands-1
+    for j = i+1:nBands
+        interNames{end+1} = sprintf('MI_B%d_x_B%d', i, j); %#ok<AGROW>
+        interData = [interData, (MI(i,:).*MI(j,:))']; %#ok<AGROW>
+    end
+end
+
+Xtbl = array2table([X interData], 'VariableNames', [featureNames, interNames]);
+T = [Xtbl, table(outcomeLabels(:), 'VariableNames', {'Outcome'})];
+
+% Construct formula
+formula = 'Outcome ~ 1';
+for i = 1:numel(featureNames)
+    formula = [formula, ' + ', featureNames{i}]; %#ok<AGROW>
+end
+for i = 1:numel(interNames)
+    formula = [formula, ' + ', interNames{i}]; %#ok<AGROW>
+end
+
+mdl = fitglm(T, formula, 'Distribution', 'binomial');
+
+% Result directory
+timestamp = datestr(now,'yyyy-mm-dd_HH-MM');
+resultDir = fullfile('PAC_DescriptiveModels','Results', ['logreg_interactions_' timestamp]);
+if ~exist(resultDir,'dir'); mkdir(resultDir); end
+
+% Save outputs
+save_model_summary(mdl, resultDir, [featureNames, interNames]);
+end

--- a/PAC_DescriptiveModels/logreg_with_phase_bin.m
+++ b/PAC_DescriptiveModels/logreg_with_phase_bin.m
@@ -1,0 +1,61 @@
+function logreg_with_phase_bin(modulogramStruct, outcomeLabels)
+%% LOGREG_WITH_PHASE_BIN Logistic regression using MI and peak phase bins.
+%  LOGREG_WITH_PHASE_BIN(modStruct, labels) extends the basic model by
+%  including the peak phase bin index of the amplitude distribution for each
+%  frequency band in addition to the modulation index (MI). This allows
+%  assessing whether the preferred phase provides extra predictive power.
+%
+%  Results are written to a timestamped folder under
+%  PAC_DescriptiveModels/Results/logreg_phase_<timestamp>/.
+%
+%  The folder contains coefficient tables, diagnostic plots, ROC curve and
+%  confusion matrix, plus a grouped bar plot comparing MI and phase-bin
+%  coefficient magnitudes.
+%
+%  Example:
+%      logreg_with_phase_bin(modStruct, labels)
+%
+%  See also SAVE_MODEL_SUMMARY.
+
+% Validate inputs
+MI = modulogramStruct.MI_per_trial;
+Amp = modulogramStruct.AmplP_per_trial; % [nBands x nTrials x nPhaseBins]
+[nBands, nTrials, nPhaseBins] = size(Amp);
+assert(isequal(size(MI,1), nBands) && size(MI,2) == nTrials, 'MI_per_trial size mismatch');
+assert(numel(outcomeLabels) == nTrials, 'Outcome labels must match trial count');
+
+% Determine peak phase bin per trial
+[~, peakBin] = max(Amp, [], 3);  % [nBands x nTrials]
+
+% Build predictor table
+featureNames = [strcat('MI_B', string(1:nBands)), strcat('PhaseBin_B', string(1:nBands))];
+X = array2table([MI'; peakBin']', 'VariableNames', featureNames);
+T = [X, table(outcomeLabels(:), 'VariableNames', {'Outcome'})];
+
+% Construct formula including all predictors linearly
+formula = 'Outcome ~ 1';
+for i = 1:nBands
+    formula = [formula, ' + MI_B', num2str(i), ' + PhaseBin_B', num2str(i)]; %#ok<AGROW>
+end
+
+mdl = fitglm(T, formula, 'Distribution', 'binomial');
+
+% Prepare result directory
+timestamp = datestr(now,'yyyy-mm-dd_HH-MM');
+resultDir = fullfile('PAC_DescriptiveModels','Results', ['logreg_phase_' timestamp]);
+if ~exist(resultDir,'dir'); mkdir(resultDir); end
+
+% Save standard outputs
+save_model_summary(mdl, resultDir, featureNames);
+
+% Additional bar plot comparing MI vs Phase coefficients
+coefTbl = mdl.Coefficients;
+miIdx = contains(coefTbl.Properties.RowNames, 'MI_B');
+phaseIdx = contains(coefTbl.Properties.RowNames, 'PhaseBin_B');
+fig = figure('Visible', 'off');
+bar(categorical({'MI','Phase'}), [mean(abs(coefTbl.Estimate(miIdx))) mean(abs(coefTbl.Estimate(phaseIdx)))]);
+ylabel('Mean |Coefficient|');
+title('Contribution of MI vs Phase Bin');
+print(fig, fullfile(resultDir,'MI_vs_Phase_contribution.png'), '-dpng');
+close(fig);
+end

--- a/PAC_DescriptiveModels/save_model_summary.m
+++ b/PAC_DescriptiveModels/save_model_summary.m
@@ -1,0 +1,81 @@
+function save_model_summary(mdl, resultDir, featureNames)
+%SAVE_MODEL_SUMMARY Save logistic regression results and diagnostics.
+%   save_model_summary(mdl, resultDir, featureNames) saves coefficient
+%   information, diagnostic plots, and model statistics for the provided
+%   GeneralizedLinearModel object MDL into RESULTDIR. FEATURENAMES should be
+%   a cell array containing the names of the predictor variables in the
+%   order used to train MDL.
+%
+%   The function writes:
+%       coefficients.csv  - table of coefficients with SE and p-values
+%       coefficients.mat  - MATLAB version of the table
+%       glm_model.mat     - the full GeneralizedLinearModel object
+%       model_summary.txt - textual output from the model
+%       coef_bar.png      - bar chart of coefficients with 95% CI
+%       roc_curve.png     - ROC curve for model predictions
+%       confusion_matrix.png - Confusion matrix at 0.5 threshold
+%       residuals.png     - (optional) residual diagnostic plot
+%
+%   RESULTDIR must exist prior to calling this function.
+
+if nargin < 3 || isempty(featureNames)
+    featureNames = mdl.PredictorNames;
+end
+
+% Save coefficient table
+coefTbl = mdl.Coefficients;
+coefCSV = fullfile(resultDir, 'coefficients.csv');
+coefMAT = fullfile(resultDir, 'coefficients.mat');
+writecell([coefTbl.Properties.VariableNames; table2cell(coefTbl)], coefCSV);
+save(coefMAT, 'coefTbl');
+
+% Save model object
+save(fullfile(resultDir, 'glm_model.mat'), 'mdl');
+
+% Create textual summary
+summaryStr = evalc('disp(mdl)');
+summaryFile = fullfile(resultDir, 'model_summary.txt');
+fid = fopen(summaryFile, 'w');
+fprintf(fid, '%s\n', summaryStr);
+% Add goodness-of-fit metrics
+pseudoR2 = 1 - mdl.Deviance/mdl.NullDeviance;
+fprintf(fid, '\nAIC: %.4f\nDeviance: %.4f\nPseudo-R2: %.4f\n', mdl.ModelCriterion.AIC, mdl.Deviance, pseudoR2);
+fclose(fid);
+
+% Plot coefficients with 95% CI
+fig = figure('Visible', 'off');
+coef = coefTbl.Estimate;
+ci = coefTbl.SE * 1.96; % approximate 95% CI
+bar(1:numel(coef), coef);
+hold on;
+errorbar(1:numel(coef), coef, ci, '.k', 'LineWidth', 1);
+set(gca, 'XTick', 1:numel(coef), 'XTickLabel', coefTbl.Properties.RowNames, 'XTickLabelRotation', 45);
+ylabel('Coefficient Estimate');
+title('Logistic Regression Coefficients');
+box off;
+print(fig, fullfile(resultDir, 'coef_bar.png'), '-dpng');
+close(fig);
+
+% ROC curve
+fig = figure('Visible', 'off');
+[X,Y,~,AUC] = perfcurve(mdl.Variables.(mdl.ResponseName), mdl.Fitted.Probability, 1);
+plot(X,Y); grid on;
+xlabel('False positive rate'); ylabel('True positive rate');
+title(sprintf('ROC Curve (AUC = %.3f)', AUC));
+print(fig, fullfile(resultDir, 'roc_curve.png'), '-dpng');
+close(fig);
+
+% Confusion matrix at 0.5 threshold
+predLabels = mdl.Fitted.Probability >= 0.5;
+cm = confusionmat(mdl.Variables.(mdl.ResponseName), predLabels);
+fig = figure('Visible', 'off');
+confusionchart(cm, {'0','1'});
+print(fig, fullfile(resultDir, 'confusion_matrix.png'), '-dpng');
+close(fig);
+
+% Residuals diagnostics
+fig = figure('Visible', 'off');
+plotResiduals(mdl, 'fitted');
+print(fig, fullfile(resultDir, 'residuals.png'), '-dpng');
+close(fig);
+end


### PR DESCRIPTION
## Summary
- create `PAC_DescriptiveModels` directory with results subfolder
- implement helper `save_model_summary` for exporting GLM diagnostics
- add three logistic regression scripts for analyzing modulogram data

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6855823bd8308326befb3f9ca26a1896