### PR TITLE
Fix logging bug and add custom output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,12 @@ Most scripts expect data files that are not part of this repository (e.g., `loss
   `resultsDir/<Subject>/Session_<N>/<alignment>/CH###_<alignment>_Modulogram.png`.
   A log file named `pipeline_<timestamp>.log` is also written to `resultsDir` and
   a consolidated MATLAB structure containing all computed data and metadata is
-  saved as `allSubjects_session<N>_<timestamp>.mat` for downstream analysis.
+ saved as `allSubjects_session<N>_<timestamp>.mat` for downstream analysis.
 3. After modulograms are generated, use `config_stats.m` followed by `run_pac_stats.m` to compute summary statistics and plots.
+4. To analyze modulograms for subject EMU024 across three sessions, use
+   `analyze_EMU024_sessions(baseDir, outDir)`. The optional `outDir`
+   argument allows writing results to a custom directory (defaults to
+   `fullfile(baseDir, 'analysis')`).
 
 ## Requirements
 

--- a/analyze_EMU024_sessions.m
+++ b/analyze_EMU024_sessions.m
@@ -1,27 +1,31 @@
-function analyze_EMU024_sessions(baseDir)
+function analyze_EMU024_sessions(baseDir, outDir)
 % ANALYZE_EMU024_SESSIONS Analyze modulogram outputs for EMU024 across three sessions.
-%   analyze_EMU024_sessions(BASEDIR) expects BASEDIR to contain folders
+%   analyze_EMU024_sessions(BASEDIR, OUTDIR) expects BASEDIR to contain folders
 %   produced by batch_modulogram.m for EMU024 sessions 1-3 with the win
 %   alignment. Each folder must include an AUC_ranking.txt file under
 %   EMU024/Session_N and a corresponding EMU024_sessionN_struct.mat file.
-%   Results are written to an "analysis" subfolder inside BASEDIR.
+%   Results are written to OUTDIR, which defaults to an "analysis" subfolder
+%   inside BASEDIR if not specified.
 %
 %   The script logs progress and errors to analysis_log_sessionN.txt for
 %   each session and saves summary figures and correlation tables in the
 %   analysis folder.
 %
 %   Example:
-%       analyze_EMU024_sessions('trial-run-3');
+%       analyze_EMU024_sessions('trial-run-3', 'trial-run-3/analysis');
 
 if nargin < 1
     baseDir = 'trial-run-3';
+end
+if nargin < 2 || isempty(outDir)
+    outDir = fullfile(baseDir, 'analysis');
 end
 
 subjectID    = 'EMU024';
 sessionNums  = 1:3;
 sessionDirs  = arrayfun(@(n) fullfile(baseDir, sprintf('%s_win_mod30-120_session%d_bw5_bins36', subjectID, n)), ...
                         sessionNums, 'UniformOutput', false);
-analysisDir  = fullfile(baseDir, 'analysis');
+analysisDir  = outDir;
 if ~exist(analysisDir, 'dir'); mkdir(analysisDir); end
 
 %% Storage for later comparisons
@@ -46,18 +50,18 @@ for i = 1:numel(sessionNums)
     structFile = fullfile(sesDir, sprintf('%s_session%d_struct.mat', subjectID, ses));
     if ~exist(structFile, 'file')
         logf(logFID, 'Struct file missing: %s\n', structFile);
-        fclose(logFID); continue; end
+        fclose(logFID); logFIDs(i) = -1; continue; end
     try
         data = load(structFile);
     catch ME
         logf(logFID, 'Error loading struct: %s\n', ME.message);
-        fclose(logFID); continue;
+        fclose(logFID); logFIDs(i) = -1; continue;
     end
     try
         sessStruct = data.allData.(subjectID).session(ses).alignment.win.channel;
     catch ME
         logf(logFID, 'Malformed structure: %s\n', ME.message);
-        fclose(logFID); continue;
+        fclose(logFID); logFIDs(i) = -1; continue;
     end
     chNames = fieldnames(sessStruct);
     logf(logFID, 'Found %d channels. Listing regions...\n', numel(chNames));
@@ -123,7 +127,7 @@ for i = 1:numel(sessionNums)
         roiChLabels{i} = {};
     end
 
-    fclose(logFID);
+    % keep logFID open for cross-session summaries
 end
 
 %% --- Correlations of top AUCs ---


### PR DESCRIPTION
## Summary
- allow `analyze_EMU024_sessions` to accept an optional output directory
- keep session log files open until all summaries are written
- document the new argument in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e4d0c76608326bc6372ea10af7ff6