### PR TITLE
Fix legend and allow custom output

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,12 @@ Most scripts expect data files that are not part of this repository (e.g., `loss
   `resultsDir/<Subject>/Session_<N>/<alignment>/CH###_<alignment>_Modulogram.png`.
   A log file named `pipeline_<timestamp>.log` is also written to `resultsDir` and
   a consolidated MATLAB structure containing all computed data and metadata is
-  saved as `allSubjects_session<N>_<timestamp>.mat` for downstream analysis.
+ saved as `allSubjects_session<N>_<timestamp>.mat` for downstream analysis.
 3. After modulograms are generated, use `config_stats.m` followed by `run_pac_stats.m` to compute summary statistics and plots.
+4. To analyze modulograms for subject EMU024 across three sessions, use
+   `analyze_EMU024_sessions(baseDir, outDir)`. The optional `outDir`
+   argument allows writing results to a custom directory (defaults to
+   `fullfile(baseDir, 'EMU024_analysis')`).
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- refine legend creation using DisplayName to avoid warnings
- document optional output directory for EMU024 analysis

## Testing
- `octave --eval "try; analyze_EMU024_sessions('trial-run-3'); catch ME; disp(ME.message); end;"` *(fails: `getReport` undefined)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e4d0c76608326bc6372ea10af7ff6