### PR TITLE
Handle single-trial case in MI drift

### DIFF
--- a/analyze_EMU024_sessions.m
+++ b/analyze_EMU024_sessions.m
@@ -58,7 +58,14 @@ for i = 1:numel(sessionNums)
         fclose(logFID); logFIDs(i) = -1; continue;
     end
     try
-        sessStruct = data.allData.(subjectID).session(ses).alignment.win.channel;
+        alignWin = data.allData.(subjectID).session(ses).alignment.win;
+        if isfield(alignWin, 'channel');
+            sessStruct = alignWin.channel;
+        elseif isfield(alignWin, 'channels');
+            sessStruct = alignWin.channels;
+        else
+            error('No channel data found');
+        end
     catch ME
         logf(logFID, 'Malformed structure: %s\n', ME.message);
         fclose(logFID); logFIDs(i) = -1; continue;
@@ -246,9 +253,16 @@ for i = 1:numel(trialMI)
         continue; end
     nTrials = size(trialMI{i}, 2);
     meanPerTrial = mean(trialMI{i}, 1, 'omitnan');
-    mdl = fitlm((1:nTrials)', meanPerTrial');
-    slope = mdl.Coefficients.Estimate(2);
-    pval  = mdl.Coefficients.pValue(2);
+    trialIdx = 1:nTrials;
+    validIdx = ~isnan(meanPerTrial);
+    if sum(validIdx) > 1
+        mdl = fitlm(trialIdx(validIdx)', meanPerTrial(validIdx)');
+        slope = mdl.Coefficients.Estimate(2);
+        pval  = mdl.Coefficients.pValue(2);
+    else
+        slope = NaN;
+        pval  = NaN;
+    end
     note = '';
     if pval < 0.05
         note = ' **SIGNIFICANT**';

--- a/misc/render_single_from_struct_file.m
+++ b/misc/render_single_from_struct_file.m
@@ -5,7 +5,14 @@ function render_single_from_struct_file(structFile, subjectID, channelLabel, out
     % Navigate to the correct nested struct
     try
         channelField = ['CH' channelLabel];  % e.g., 'CH057'
-        resultStruct = s.allData.(subjectID).session.alignment.win.channel.(channelField);
+        alignWin = s.allData.(subjectID).session.alignment.win;
+        if isfield(alignWin, 'channel')
+            resultStruct = alignWin.channel.(channelField);
+        elseif isfield(alignWin, 'channels')
+            resultStruct = alignWin.channels.(channelField);
+        else
+            error('No channel data found');
+        end
     catch
         error('Channel %s not found in struct at expected location.', channelField);
     end

--- a/misc/run_pac_stats.m
+++ b/misc/run_pac_stats.m
@@ -6,8 +6,11 @@ function run_pac_stats(config)
     subjectID = config.subjectID;
     sesnum    = config.sessionNum;
 
-    lossStruct = lossData.allData.(subjectID).session(sesnum).alignment.loss.channel;
-    winStruct  = winData.allData.(subjectID).session(sesnum).alignment.win.channel;
+    % Support both 'channel' and 'channels' field names
+    alignLoss = lossData.allData.(subjectID).session(sesnum).alignment.loss;
+    alignWin  = winData.allData.(subjectID).session(sesnum).alignment.win;
+    if isfield(alignLoss, 'channel'); lossStruct = alignLoss.channel; else; lossStruct = alignLoss.channels; end
+    if isfield(alignWin, 'channel');  winStruct  = alignWin.channel;  else; winStruct  = alignWin.channels;  end
 
     lossChs = fieldnames(lossStruct);
     winChs  = fieldnames(winStruct);

--- a/modulogram_pipeline.m
+++ b/modulogram_pipeline.m
@@ -97,6 +97,8 @@ for subjIdx = 1:numel(config.subjects)
             end
             chanField = ['CH' channelLabel];
             allData.(subjectID).session(sesnum).alignment.(alignment).channel.(chanField) = modStruct;
+            % Provide backward-compatible field name expected by other pipelines
+            allData.(subjectID).session(sesnum).alignment.(alignment).channels.(chanField) = modStruct;
         end
     end
     subjectFile = fullfile(config.resultsDir, sprintf('%s_session%d_struct.mat', subjectID, sesnum));


### PR DESCRIPTION
## Summary
- skip trial MI regression when only one valid trial exists
- store modulograms under `channels` as well as `channel`
- fallback to either field when analyzing results

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685e5c6a92d88326be1ad8d60522ea05